### PR TITLE
Add optional parameter that would allow to rename image before save in gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ npm install francisco-sanchez-molina/react-native-store-photos-album --save
 
 ## Usage
 
+```JavaScript
 import CameraRollExtended from 'react-native-store-photos-album'
 
 CameraRollExtended.saveToCameraRoll({uri: photoPath, album: 'Test'}, 'photo')
+```
+or with additional `fileName` parameter (it could rename image, works only on Android):
+
+```JavaScript
+CameraRollExtended.saveToCameraRoll({uri: photoPath, album: 'Test', fileName: 'greatPicture.jpg'}, 'photo')
+```
 
 version 0.1.0 add react-native 0.40 support

--- a/android/src/main/java/com/devialab/camerarollextended/CameraRoll.java
+++ b/android/src/main/java/com/devialab/camerarollextended/CameraRoll.java
@@ -119,7 +119,8 @@ public class CameraRoll extends ReactContextBaseJavaModule {
   @ReactMethod
   public void saveToCameraRoll(ReadableMap tag, String type, Promise promise) {
     MediaType parsedType = type.equals("video") ? MediaType.VIDEO : MediaType.PHOTO;
-    new SaveToCameraRoll(getReactApplicationContext(), Uri.parse(tag.getString("uri")), tag.getString("album"), parsedType, promise)
+    String fileName = tag.hasKey("fileName") ? tag.getString("fileName") : null;
+    new SaveToCameraRoll(getReactApplicationContext(), Uri.parse(tag.getString("uri")), tag.getString("album"), fileName, parsedType, promise)
         .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
   }
 
@@ -129,16 +130,18 @@ public class CameraRoll extends ReactContextBaseJavaModule {
     private final Context mContext;
     private final Uri mUri;
     private final String mAlbum;
+    private final String mFileName;
     private final Promise mPromise;
     private final MediaType mType;
 
-    public SaveToCameraRoll(ReactContext context, Uri uri, String album, MediaType type, Promise promise) {
+    public SaveToCameraRoll(ReactContext context, Uri uri, String album, String fileName, MediaType type, Promise promise) {
       super(context);
       mContext = context;
       mUri = uri;
       mAlbum = album;
       mPromise = promise;
       mType = type;
+      mFileName = fileName;
     }
 
     @Override
@@ -154,10 +157,11 @@ public class CameraRoll extends ReactContextBaseJavaModule {
         if (!exportDir.isDirectory()) {
           mPromise.reject(ERROR_UNABLE_TO_LOAD, "External media storage directory not available");
           return;
-        }
-        File dest = new File(exportDir, source.getName());
+        }        
+        String fullSourceName = mFileName == null ? source.getName() : mFileName;
+
+        File dest = new File(exportDir, fullSourceName);
         int n = 0;
-        String fullSourceName = source.getName();
         String sourceName, sourceExt;
         if (fullSourceName.indexOf('.') >= 0) {
           sourceName = fullSourceName.substring(0, fullSourceName.lastIndexOf('.'));
@@ -165,7 +169,7 @@ public class CameraRoll extends ReactContextBaseJavaModule {
         } else {
           sourceName = fullSourceName;
           sourceExt = "";
-        }
+        }        
         while (!dest.createNewFile()) {
           dest = new File(exportDir, sourceName + "_" + (n++) + sourceExt);
         }


### PR DESCRIPTION
As I'm using `react-native-store-photos-album` together with `react-native-view-shot`, I needed some way to change temporary name from `react-native-view-shot` to something more user-friendly.
On iOS it is smaller issue, as there is no easy way to find filename there. 

This PR updates android implementation to check if there is `fileName` passed form React, and then use it as a name instead of sourceName. All logic to deduplicate names should still work.
I also updated documentation to include this param.